### PR TITLE
Add numerically predicates.

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -56,6 +56,14 @@ module Dry
         input.is_a?(Time)
       end
 
+      predicate(:number?) do |input|
+        begin
+          true if Float(input)
+        rescue ArgumentError, TypeError
+          false
+        end
+      end
+
       predicate(:int?) do |input|
         input.is_a?(Fixnum)
       end
@@ -78,6 +86,14 @@ module Dry
 
       predicate(:array?) do |input|
         input.is_a?(Array)
+      end
+
+      predicate(:odd?) do |input|
+        input.odd?
+      end
+
+      predicate(:even?) do |input|
+        input.even?
       end
 
       predicate(:lt?) do |num, input|

--- a/spec/unit/predicates/even_spec.rb
+++ b/spec/unit/predicates/even_spec.rb
@@ -1,0 +1,31 @@
+require 'dry/logic/predicates'
+
+RSpec.describe Dry::Logic::Predicates do
+  describe '#even?' do
+    let(:predicate_name) { :even? }
+
+    context 'when value is an odd int' do
+      let(:arguments_list) do
+        [
+          [13],
+          [1],
+          [1111]
+        ]
+      end
+
+      it_behaves_like 'a failing predicate'
+    end
+
+    context 'with value is an even int' do
+      let(:arguments_list) do
+        [
+          [0],
+          [2],
+          [2222]
+        ]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+  end
+end

--- a/spec/unit/predicates/number_spec.rb
+++ b/spec/unit/predicates/number_spec.rb
@@ -1,0 +1,37 @@
+require 'dry/logic/predicates'
+
+RSpec.describe Dry::Logic::Predicates do
+  describe '#number?' do
+    let(:predicate_name) { :number? }
+
+    context 'when value is numerical' do
+      let(:arguments_list) do
+        [
+          ["34"],
+          ["1.000004"],
+          ["0"],
+          [4],
+          ["-15.24"],
+          [-3.5]
+        ]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+
+    context 'with value is not numerical' do
+      let(:arguments_list) do
+        [
+          [''],
+          ["-14px"],
+          ["10,150.00"],
+          [nil],
+          [:symbol],
+          [String]
+        ]
+      end
+
+      it_behaves_like 'a failing predicate'
+    end
+  end
+end

--- a/spec/unit/predicates/odd_spec.rb
+++ b/spec/unit/predicates/odd_spec.rb
@@ -1,0 +1,31 @@
+require 'dry/logic/predicates'
+
+RSpec.describe Dry::Logic::Predicates do
+  describe '#odd?' do
+    let(:predicate_name) { :odd? }
+
+    context 'when value is an odd int' do
+      let(:arguments_list) do
+        [
+          [13],
+          [1],
+          [1111]
+        ]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+
+    context 'with value is an even int' do
+      let(:arguments_list) do
+        [
+          [0],
+          [2],
+          [2222]
+        ]
+      end
+
+      it_behaves_like 'a failing predicate'
+    end
+  end
+end


### PR DESCRIPTION
Fixes #5.

Jury is out on the `:number?`  predicate.

It appears to be quicker to test if ruby can float a string than match a regex. 

The downside is that this doesn't cover the edge cases that the regexps in coercible do, and you have rescue potential errors.

What are your thoughts @solnic. Happy to revise.

```
require "benchmark"

Benchmark.bm(7) do |x|
  x.report("float_conversion:") { (1..10000).each { |i| Float(Random.new.rand(i).to_s) } }
  x.report("regex_conversion:") { (1..10000).each { |i| Regexp.new(/\A[+-]?\d+\Z/).match(Random.new.rand(i).to_s) } }
end

                   user       system     total    real
float_conversion:  0.100000   0.070000   0.170000 (  0.169644)
regex_conversion:  0.200000   0.080000   0.280000 (  0.279153)

```