### PR TITLE
add a not_eql? predicate

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -142,7 +142,7 @@ module Dry
       end
 
       predicate(:not_eql?) do |left, right|
-        !self[:eql?].(left, right)
+        !left.eql?(right)
       end
 
       predicate(:true?) do |value|

--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -141,6 +141,10 @@ module Dry
         left.eql?(right)
       end
 
+      predicate(:not_eql?) do |left, right|
+        !self[:eql?].(left, right)
+      end
+
       predicate(:true?) do |value|
         value === true
       end

--- a/spec/unit/predicates/not_eql_spec.rb
+++ b/spec/unit/predicates/not_eql_spec.rb
@@ -1,0 +1,21 @@
+require 'dry/logic/predicates'
+
+RSpec.describe Dry::Logic::Predicates, '#not_eql?' do
+  let(:predicate_name) { :not_eql? }
+
+  context 'when value is equal to the arg' do
+    let(:arguments_list) do
+      [['Foo', 'Foo']]
+    end
+
+    it_behaves_like 'a failing predicate'
+  end
+
+  context 'with value is not equal to the arg' do
+    let(:arguments_list) do
+      [['Bar', 'Foo']]
+    end
+
+    it_behaves_like 'a passing predicate'
+  end
+end


### PR DESCRIPTION
Maybe I’m just lazy but this seemed a pretty useful one to have even if
it is just `!eql?`