### PR TITLE
Add includes? and excludes? predicates, rename inclusion? and exclusion?

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -134,7 +134,15 @@ module Dry
       end
 
       predicate(:exclusion?) do |list, input|
-        !self[:inclusion?].(list, input)
+        !list.include?(input)
+      end
+
+      predicate(:includes?) do |value, input|
+        input.include?(value)
+      end
+
+      predicate(:excludes?) do |value, input|
+        !input.include?(value)
       end
 
       predicate(:eql?) do |left, right|

--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -130,10 +130,20 @@ module Dry
       end
 
       predicate(:inclusion?) do |list, input|
-        list.include?(input)
+        ::Kernel.warn 'inclusion is deprecated - use included_in instead.'
+        self[:included_in?].(list, input)
       end
 
       predicate(:exclusion?) do |list, input|
+        ::Kernel.warn 'exclusion is deprecated - use excluded_from instead.'
+        self[:excluded_from?].(list, input)
+      end
+
+      predicate(:included_in?) do |list, input|
+        list.include?(input)
+      end
+
+      predicate(:excluded_from?) do |list, input|
         !list.include?(input)
       end
 

--- a/spec/unit/predicates/excluded_from_spec.rb
+++ b/spec/unit/predicates/excluded_from_spec.rb
@@ -1,8 +1,8 @@
 require 'dry/logic/predicates'
 
 RSpec.describe Dry::Logic::Predicates do
-  describe '#exclusion?' do
-    let(:predicate_name) { :exclusion? }
+  describe '#excluded_from?' do
+    let(:predicate_name) { :excluded_from? }
 
     context 'when value is not present in list' do
       let(:arguments_list) do

--- a/spec/unit/predicates/excludes_spec.rb
+++ b/spec/unit/predicates/excludes_spec.rb
@@ -1,0 +1,35 @@
+require 'dry/logic/predicates'
+
+RSpec.describe Dry::Logic::Predicates do
+  describe '#excludes?' do
+    let(:predicate_name) { :excludes? }
+
+    context 'with input excludes value' do
+      let(:arguments_list) do
+        [
+          ['Jack', ['Jill', 'John']],
+          [0, 1..2],
+          [3, 1..2],
+          [true, [nil, false]]
+        ]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+
+    context 'when input includes value' do
+      let(:arguments_list) do
+        [
+          ['Jill', ['Jill', 'John']],
+          ['John', ['Jill', 'John']],
+          [1, 1..2],
+          [2, 1..2],
+          [nil, [nil, false]],
+          [false, [nil, false]]
+        ]
+      end
+
+      it_behaves_like 'a failing predicate'
+    end
+  end
+end

--- a/spec/unit/predicates/included_in_spec.rb
+++ b/spec/unit/predicates/included_in_spec.rb
@@ -1,8 +1,8 @@
 require 'dry/logic/predicates'
 
 RSpec.describe Dry::Logic::Predicates do
-  describe '#inclusion?' do
-    let(:predicate_name) { :inclusion? }
+  describe '#included_in?' do
+    let(:predicate_name) { :included_in? }
 
     context 'when value is present in list' do
       let(:arguments_list) do

--- a/spec/unit/predicates/includes_spec.rb
+++ b/spec/unit/predicates/includes_spec.rb
@@ -1,0 +1,35 @@
+require 'dry/logic/predicates'
+
+RSpec.describe Dry::Logic::Predicates do
+  describe '#includes?' do
+    let(:predicate_name) { :includes? }
+
+    context 'when input includes value' do
+      let(:arguments_list) do
+        [
+          ['Jill', ['Jill', 'John']],
+          ['John', ['Jill', 'John']],
+          [1, 1..2],
+          [2, 1..2],
+          [nil, [nil, false]],
+          [false, [nil, false]]
+        ]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+
+    context 'with input excludes value' do
+      let(:arguments_list) do
+        [
+          ['Jack', ['Jill', 'John']],
+          [0, 1..2],
+          [3, 1..2],
+          [true, [nil, false]]
+        ]
+      end
+
+      it_behaves_like 'a failing predicate'
+    end
+  end
+end


### PR DESCRIPTION
Added the new predicates & converted the current `exclusion?` predicate
to avoid having to navigate the predicate_set for performance reasons.

TODO: Confirm naming of predicates