### PR TITLE
Minimise errors when using includes & excludes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 sudo: false
 cache: bundler
-bundler_args: --without console benchmarks
+bundler_args: --without console tools
 script:
   - bundle exec rake spec
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 sudo: false
 cache: bundler
-bundler_args: --without console
+bundler_args: --without console benchmarks
 script:
   - bundle exec rake spec
 rvm:

--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -149,8 +149,8 @@ module Dry
 
       predicate(:includes?) do |value, input|
         begin
-          case input
-          when String, Range, Array, Hash then input.include?(value)
+          if input.respond_to?(:include?)
+            input.include?(value)
           else
             false
           end

--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -148,11 +148,19 @@ module Dry
       end
 
       predicate(:includes?) do |value, input|
-        input.include?(value)
+        begin
+          case input
+          when String, Range, Array, Hash then input.include?(value)
+          else
+            false
+          end
+        rescue TypeError
+          false
+        end
       end
 
       predicate(:excludes?) do |value, input|
-        !input.include?(value)
+        !self[:includes?].(value, input)
       end
 
       predicate(:eql?) do |left, right|

--- a/spec/unit/predicates/excludes_spec.rb
+++ b/spec/unit/predicates/excludes_spec.rb
@@ -10,7 +10,25 @@ RSpec.describe Dry::Logic::Predicates do
           ['Jack', ['Jill', 'John']],
           [0, 1..2],
           [3, 1..2],
+          ['foo', 'Hello World'],
+          [:foo, { bar: 0 }],
           [true, [nil, false]]
+        ]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+
+    context 'with input of invalid type' do
+      let(:arguments_list) do
+        [
+          [2, 1],
+          [1, nil],
+          ["foo", 1],
+          [1, "foo"],
+          [1..2, "foo"],
+          ["foo", 1..2],
+          [:key, "foo"]
         ]
       end
 
@@ -24,6 +42,9 @@ RSpec.describe Dry::Logic::Predicates do
           ['John', ['Jill', 'John']],
           [1, 1..2],
           [2, 1..2],
+          ['Hello', 'Hello World'],
+          ['World', 'Hello World'],
+          [:bar, { bar: 0 }],
           [nil, [nil, false]],
           [false, [nil, false]]
         ]

--- a/spec/unit/predicates/includes_spec.rb
+++ b/spec/unit/predicates/includes_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe Dry::Logic::Predicates do
           ['John', ['Jill', 'John']],
           [1, 1..2],
           [2, 1..2],
+          ['Hello', 'Hello World'],
+          ['World', 'Hello World'],
+          [:bar, { bar: 0 }],
           [nil, [nil, false]],
           [false, [nil, false]]
         ]
@@ -19,12 +22,30 @@ RSpec.describe Dry::Logic::Predicates do
       it_behaves_like 'a passing predicate'
     end
 
+    context 'with input of invalid type' do
+      let(:arguments_list) do
+        [
+          [2, 1],
+          [1, nil],
+          ["foo", 1],
+          [1, "foo"],
+          [1..2, "foo"],
+          ["foo", 1..2],
+          [:key, "foo"]
+        ]
+      end
+
+      it_behaves_like 'a failing predicate'
+    end
+
     context 'with input excludes value' do
       let(:arguments_list) do
         [
           ['Jack', ['Jill', 'John']],
           [0, 1..2],
           [3, 1..2],
+          ['foo', 'Hello World'],
+          [:foo, { bar: 0 }],
           [true, [nil, false]]
         ]
       end


### PR DESCRIPTION
If includes is called on an input that supports the method then call
it, otherwise return false.

If we encounter a type error (e.g. String.include?(Integer) ) then also
return false.

Due to the enhanced complexity of the predicate lets make excludes?
simply be its opposite.

Fixes https://github.com/dry-rb/dry-logic/issues/10