### PR TITLE
improvements to predicate handling

### DIFF
--- a/lib/dry/logic/predicate.rb
+++ b/lib/dry/logic/predicate.rb
@@ -18,12 +18,27 @@ module Dry
         @args = args
       end
 
-      def call(*args)
-        fn.(*args)
+      #as long as we keep track of the args, we don't actually need to curry the proc...
+      #if we never curry the proc then fn.arity & fn.parameters stay intact
+      def curry(*args)
+        self.class.new(id, *(@args + args), &fn)
       end
 
-      def curry(*args)
-        self.class.new(id, *args, &fn.curry.(*args))
+      def call(*args)
+        all_args = @args+args
+        if all_args.size == arity
+          fn.(*all_args)
+        else
+          raise ArgumentError, "wrong number of arguments (#{all_args.size} for #{arity})"
+        end
+      end
+
+      def arity
+        fn.arity
+      end
+
+      def parameters
+        fn.parameters
       end
 
       def to_ast

--- a/spec/shared/predicates.rb
+++ b/spec/shared/predicates.rb
@@ -30,8 +30,8 @@ RSpec.shared_examples 'a passing predicate' do
   let(:predicate) { Dry::Logic::Predicates[predicate_name] }
 
   it do
-    arguments_list.each do |(left, right)|
-      expect(predicate.call(left, right)).to be(true)
+    arguments_list.each do |args|
+      expect(predicate.call(*args)).to be(true)
     end
   end
 end
@@ -40,8 +40,8 @@ RSpec.shared_examples 'a failing predicate' do
   let(:predicate) { Dry::Logic::Predicates[predicate_name] }
 
   it do
-    arguments_list.each do |(left, right)|
-      expect(predicate.call(left, right)).to be(false)
+    arguments_list.each do |args|
+      expect(predicate.call(*args)).to be(false)
     end
   end
 end

--- a/spec/unit/predicate_spec.rb
+++ b/spec/unit/predicate_spec.rb
@@ -9,6 +9,33 @@ RSpec.describe Dry::Logic::Predicate do
 
       expect(is_empty.('filled')).to be(false)
     end
+
+    it "raises argument error when incorrect number of args provided" do
+      is_empty = Dry::Logic::Predicate.new(:is_empty) { |str| str.empty? }
+      min_age = Dry::Logic::Predicate.new(:min_age) { |age, input| input >= age }
+
+      expect { is_empty.() }.to raise_error(ArgumentError)
+      expect { min_age.curry(10).() }.to raise_error(ArgumentError)
+      expect { min_age.(18) }.to raise_error(ArgumentError)
+      expect { min_age.(18,19,20,30) }.to raise_error(ArgumentError)
+
+    end
+  end
+
+  describe '#arity' do
+    it 'returns arity of the predicate function' do
+      is_equal = Dry::Logic::Predicate.new(:is_equal) { |left, right| left == right }
+
+      expect(is_equal.arity).to eql(2)
+    end
+  end
+
+  describe '#parameters' do
+    it 'returns arity of the predicate function' do
+      is_equal = Dry::Logic::Predicate.new(:is_equal) { |left, right| left == right }
+
+      expect(is_equal.parameters).to eql([[:opt, :left], [:opt, :right]])
+    end
   end
 
   describe '#curry' do
@@ -22,6 +49,19 @@ RSpec.describe Dry::Logic::Predicate do
       expect(min_age_18.(18)).to be(true)
       expect(min_age_18.(19)).to be(true)
       expect(min_age_18.(17)).to be(false)
+    end
+
+    it 'can curry again & again' do
+      min_age = Dry::Logic::Predicate.new(:min_age) { |age, input| input >= age }
+
+      min_age_18 = min_age.curry(18)
+
+      expect(min_age_18.args).to eql([18])
+
+      actual_age_19 = min_age_18.curry(19)
+
+      expect(actual_age_19.()).to be(true)
+      expect(actual_age_19.args).to eql([18,19])
     end
   end
 end


### PR DESCRIPTION
1) update shared specs to work with predicates where airity != 2
2) capture predicate args without currying the function to maintain
airity and parameters
3) add specs for access to predicate airity & parameters
3) raise errors when calling a predicate with invalid no. args.