### PR TITLE
Enable predicates that don't need input

### DIFF
--- a/lib/dry/logic/predicate.rb
+++ b/lib/dry/logic/predicate.rb
@@ -21,15 +21,25 @@ module Dry
       #as long as we keep track of the args, we don't actually need to curry the proc...
       #if we never curry the proc then fn.arity & fn.parameters stay intact
       def curry(*args)
-        self.class.new(id, *(@args + args), &fn)
+        all_args = @args+args
+        if all_args.size <= arity
+          self.class.new(id, *all_args, &fn)
+        else
+          raise_arity_error(all_args.size)
+        end
       end
 
+      #enables a rule to call with its params & have them ignored if the
+      #predicate doesn't need them.
+      #if @args.size == arity then we should ignore called args
       def call(*args)
         all_args = @args+args
-        if all_args.size == arity
+        if @args.size == arity
+          fn.(*@args)
+        elsif all_args.size == arity
           fn.(*all_args)
         else
-          raise ArgumentError, "wrong number of arguments (#{all_args.size} for #{arity})"
+          raise_arity_error(all_args.size)
         end
       end
 
@@ -45,6 +55,11 @@ module Dry
         [:predicate, [id, args]]
       end
       alias_method :to_a, :to_ast
+
+      private
+      def raise_arity_error(args_size)
+        raise ArgumentError, "wrong number of arguments (#{args_size} for #{arity})"
+      end
     end
   end
 end

--- a/spec/unit/predicate_spec.rb
+++ b/spec/unit/predicate_spec.rb
@@ -16,9 +16,21 @@ RSpec.describe Dry::Logic::Predicate do
 
       expect { is_empty.() }.to raise_error(ArgumentError)
       expect { min_age.curry(10).() }.to raise_error(ArgumentError)
+      expect { min_age.curry(10, 12, 14) }.to raise_error(ArgumentError)
       expect { min_age.(18) }.to raise_error(ArgumentError)
       expect { min_age.(18,19,20,30) }.to raise_error(ArgumentError)
+    end
 
+    it "should ignore called args if already curried with all args" do
+      min_age = Dry::Logic::Predicate.new(:min_age) { |age, input| input >= age }
+      min_age_10 = min_age.curry(10)
+      expect(min_age_10.curry(11).(15,16)).to be(true)
+    end
+
+    it "predicates should work without any args" do
+      is_empty = Dry::Logic::Predicate.new(:is_empty) { true }
+
+      expect(is_empty.()).to be(true)
     end
   end
 

--- a/spec/unit/rule/value_spec.rb
+++ b/spec/unit/rule/value_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe Dry::Logic::Rule::Value do
       it 'has no name by default' do
         expect(result.name).to be(nil)
       end
+
+      context "works with predicates.arity == 0" do
+        subject(:rule) { Dry::Logic::Rule::Value.new(predicate) }
+        let(:predicate) { Dry::Logic::Predicate.new(:without_args) { true } }
+        let(:result) { rule.("some input...") }
+
+        it "calls its predicate & ignores input arg" do
+          expect(result).to be_success
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This change will enable us to support predicates without any args.

Any args that are curried take president over those that are passed
into the call