### PR TITLE
add non_whitespace? predicate

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -6,6 +6,8 @@ module Dry
   module Logic
     module Predicates
       module Methods
+        WHITESPACE_PATTERN = /\A[[:space:]#{"\u200B\u200C\u200D\u2060\uFEFF"}]*\z/
+
         def [](name)
           method(name)
         end
@@ -37,6 +39,10 @@ module Dry
 
         def filled?(input)
           !self[:empty?].(input)
+        end
+
+        def non_whitespace?(input)
+          !(WHITESPACE_PATTERN =~ input)
         end
 
         def bool?(input)

--- a/spec/unit/predicates/empty_spec.rb
+++ b/spec/unit/predicates/empty_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe Dry::Logic::Predicates do
           ['1'],
           ['0'],
           [:symbol],
-          [String]
+          [String],
+          [' '],
         ]
       end
 

--- a/spec/unit/predicates/non_whitespace_spec.rb
+++ b/spec/unit/predicates/non_whitespace_spec.rb
@@ -2,34 +2,30 @@ require 'dry/logic/predicates'
 
 RSpec.describe Dry::Logic::Predicates do
   describe '#filled?' do
-    let(:predicate_name) { :filled? }
+    let(:predicate_name) { :non_whitespace? }
 
-    context 'when value is filled' do
+    context 'when string contains non-whitespace characters' do
       let(:arguments_list) do
         [
-          ['Jill'],
-          [[1, 2, 3]],
-          [{ name: 'John' }],
-          [true],
-          [false],
-          ['1'],
+          ['something'],
           ['0'],
-          [:symbol],
-          [String],
-          [' '],
+          ['  with trailing whitespace   '],
+          [:symbol]
         ]
       end
 
       it_behaves_like 'a passing predicate'
     end
 
-    context 'with value is not filled' do
+    context 'when string contains no non-whitespace chars ' do
       let(:arguments_list) do
         [
           [''],
-          [[]],
-          [{}],
-          [nil]
+          [' '],
+          ["\n"],
+          ["\t"],
+          [:""],
+          [:"  "],
         ]
       end
 


### PR DESCRIPTION
See https://github.com/dry-rb/dry-validation/issues/213

This is such a common use case (testing that a string is not only non-empty but contains non-whitespace characters, à la `String#present?` if you're using ActiveSupport) that I feel it makes perfect sense to include as a 'core' predicate.

However, I don't think `filled_str?` (which @solnic suggested in https://github.com/dry-rb/dry-validation/issues/213) is a good name, mainly because it uses the word "filled" in a way that's inconsistent with the existing `filled?` method: `str?("")` is true, `filled?("")` is true, but `filled_str?("")` wouldn't be true, which doesn't make sense. `non_whitespace?` is the clearest name I could come up with... although there might be something better.

Note that if you pass an object where the concept 'non whitespace' doesn't make sense (e.g. an Array or a Hash), this predicate will raise an error. (This is only true because I've written it like "regex =~ input"; if it was "input =~ regex" then non-stringy objects would just return `nil`.) I feel like raising an error makes more sense since if you're calling `non_whitespace` on an Array or an Integer etc. you're probably doing something wrong somewhere. 

Is raising an error the right approach? Some other predicates already do it, e.g. `key?` will raise an error if passed an object that doesn't respond to `key?`.
