### PR TITLE
handle deprecation warnings for Fixnum in ruby 2.4.0

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -64,11 +64,7 @@ module Dry
         end
 
         def int?(input)
-          if 1.class == Integer
-            input.is_a?(Integer)
-          else
-            input.is_a?(Fixnum)
-          end
+          input.is_a?(Integer)
         end
 
         def float?(input)
@@ -116,14 +112,8 @@ module Dry
         end
 
         def size?(size, input)
-          if 1.class == Integer
-            numeric_class = Integer
-          else
-            numeric_class = Fixnum
-          end
-
           case size
-          when numeric_class then size == input.size
+          when Integer then size == input.size
           when Range, Array then size.include?(input.size)
           else
             raise ArgumentError, "+#{size}+ is not supported type for size? predicate."

--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -64,7 +64,11 @@ module Dry
         end
 
         def int?(input)
-          input.is_a?(Fixnum)
+          if 1.class == Integer
+            input.is_a?(Integer)
+          else
+            input.is_a?(Fixnum)
+          end
         end
 
         def float?(input)
@@ -112,8 +116,14 @@ module Dry
         end
 
         def size?(size, input)
+          if 1.class == Integer
+            numeric_class = Integer
+          else
+            numeric_class = Fixnum
+          end
+
           case size
-          when Fixnum then size == input.size
+          when numeric_class then size == input.size
           when Range, Array then size.include?(input.size)
           else
             raise ArgumentError, "+#{size}+ is not supported type for size? predicate."


### PR DESCRIPTION
Handle deprecation warnings for `Fixnum` in ruby 2.4.0 by doing a simple check before accessing the constant.