### PR TITLE
Fix instance_of? checks called on schema instance in dry-v

### DIFF
--- a/lib/dry/logic/rule.rb
+++ b/lib/dry/logic/rule.rb
@@ -62,7 +62,7 @@ module Dry
       end
 
       def bind(object)
-        if predicate.instance_of?(UnboundMethod)
+        if UnboundMethod === predicate
           self.class.new(predicate.bind(object), options)
         else
           self.class.new(
@@ -73,7 +73,7 @@ module Dry
       end
 
       def eval_args(object)
-        with(args: args.map { |arg| arg.instance_of?(UnboundMethod) ? arg.bind(object).() : arg })
+        with(args: args.map { |arg| UnboundMethod === arg ? arg.bind(object).() : arg })
       end
 
       def with(new_opts)


### PR DESCRIPTION
@solnic ping me if you have any comments on this, this allows for passing injected deps into externally defined predicates

example code from dry-v
```ruby
module IssuesPredicate
  include Dry::Logic::Predicates

  predicate(:equipment_exists?) do |account, value|
    account.include?(value)
  end
end

Schema = Dry::Validation.Schema do
  configure do
    option :account
    predicates(::IssuesPredicate)
  end

  optional(:equipment_ids).each { equipment_exists?(account) }
end
```

/cc @NikitaNaumenko