### PR TITLE
Fix Operations::Negation issues.

### DIFF
--- a/lib/dry/logic/operations/negation.rb
+++ b/lib/dry/logic/operations/negation.rb
@@ -10,7 +10,11 @@ module Dry
         end
 
         def call(input)
-          Result.new(!rule[input], id) { ast(input) }
+          Result.new(rule.(input).failure?, id) { ast(input) }
+        end
+
+        def [](input)
+          !rule[input]
         end
       end
     end

--- a/spec/unit/operations/negation_spec.rb
+++ b/spec/unit/operations/negation_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe Operations::Negation do
       expect(operation.('19')).to be_success
       expect(operation.(17)).to be_failure
     end
+
+    context 'double negation' do
+      subject(:double_negation) { Operations::Negation.new(operation) }
+
+      it 'works as rule' do
+        expect(double_negation.('19')).to be_failure
+        expect(double_negation.(17)).to be_success
+      end
+    end
   end
 
   describe '#to_ast' do


### PR DESCRIPTION
* Fix inconsistency when #call calls []
* Add [] method to prevent errors when it's required, e.g. with And

I didn't find the specific issue, but this PR fixes usages of negation like
* Using negation inside of And or another operations when calling method `[]` (I used double negation for test)
* Calling `not` on `schema` in `dry-validation`(this probably needs also adding `[]` for schemas)
* Inconsistency between `call` and `[]`, i.e. all `call` methods use `call` and `[]` methods use `[]` which is not the case for Negation