### PR TITLE
Introduce part operation.

### DIFF
--- a/lib/dry/logic/operations.rb
+++ b/lib/dry/logic/operations.rb
@@ -7,6 +7,7 @@ require 'dry/logic/operations/negation'
 require 'dry/logic/operations/key'
 require 'dry/logic/operations/attr'
 require 'dry/logic/operations/each'
+require 'dry/logic/operations/part'
 require 'dry/logic/operations/set'
 require 'dry/logic/operations/check'
 

--- a/lib/dry/logic/operations/multiple.rb
+++ b/lib/dry/logic/operations/multiple.rb
@@ -1,0 +1,17 @@
+require 'dry/logic/operations/abstract'
+
+module Dry
+  module Logic
+    module Operations
+      class Multiple < Abstract
+        def ast(input = Undefined)
+          [type, rules.map { |rule| rule.ast(input) }]
+        end
+
+        def to_s
+          "#{type}(#{rules.map(&:to_s).join(', ')})"
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/logic/operations/part.rb
+++ b/lib/dry/logic/operations/part.rb
@@ -4,22 +4,24 @@ require 'dry/logic/result'
 module Dry
   module Logic
     module Operations
-      class Set < Multiple
+      class Part < Multiple
         def type
-          :set
+          :part
         end
 
         def call(input)
           results = rules.map { |rule| rule.(input) }
-          success = results.all?(&:success?)
+          success = results.any?(&:success?)
+
+          return Result::SUCCESS if success
 
           Result.new(success, id) do
-            [type, results.select(&:failure?).map { |failure| failure.to_ast }]
+            [type, results.map { |failure| failure.to_ast }]
           end
         end
 
         def [](input)
-          rules.map { |rule| rule[input] }.all?
+          rules.map { |rule| rule[input] }.any?
         end
       end
     end

--- a/lib/dry/logic/result.rb
+++ b/lib/dry/logic/result.rb
@@ -93,6 +93,14 @@ module Dry
       def visit_hint(node)
         visit(node)
       end
+
+      def visit_set(nodes)
+        "set(#{nodes.map { |node| visit(node) }.join(', ')})"
+      end
+
+      def visit_part(nodes)
+        "part(#{nodes.map { |node| visit(node) }.join(', ')})"
+      end
     end
   end
 end

--- a/lib/dry/logic/rule_compiler.rb
+++ b/lib/dry/logic/rule_compiler.rb
@@ -40,6 +40,10 @@ module Dry
         Operations::Attr.new(visit(predicate), name: name)
       end
 
+      def visit_part(node)
+        Operations::Part.new(*call(node))
+      end
+
       def visit_set(node)
         Operations::Set.new(*call(node))
       end

--- a/spec/shared/predicates.rb
+++ b/spec/shared/predicates.rb
@@ -34,6 +34,8 @@ RSpec.shared_examples 'predicates' do
   let(:case?) { Dry::Logic::Predicates[:case?] }
 
   let(:equal?) { Dry::Logic::Predicates[:equal?] }
+
+  let(:odd?) { Dry::Logic::Predicates[:odd?] }
 end
 
 RSpec.shared_examples 'a passing predicate' do

--- a/spec/unit/operations/part_spec.rb
+++ b/spec/unit/operations/part_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe Operations::Part do
+  subject(:operation) { Operations::Part.new(is_odd, gt_18) }
+
+  include_context 'predicates'
+
+  let(:is_odd) { Rule::Predicate.new(odd?) }
+  let(:gt_18) { Rule::Predicate.new(gt?, args: [18]) }
+
+  describe '#call' do
+    it 'applies at least one of its rules to the input' do
+      expect(operation.(20)).to be_success
+      expect(operation.(17)).to be_success
+      expect(operation.(16)).to be_failure
+    end
+  end
+
+  describe '#to_ast' do
+    it 'returns ast' do
+      expect(operation.to_ast).to eql(
+        [:part, [[:predicate, [:odd?, [[:input, Undefined]]]], [:predicate, [:gt?, [[:num, 18], [:input, Undefined]]]]]]
+      )
+    end
+
+    it 'returns result ast' do
+      expect(operation.(16).to_ast).to eql(
+        [:part, [[:predicate, [:odd?, [[:input, 16]]]], [:predicate, [:gt?, [[:num, 18], [:input, 16]]]]]]
+      )
+    end
+
+    it 'returns result ast with an :id' do
+      expect(operation.with(id: :age).(16).to_ast).to eql(
+        [:failure, [:age, [:part, [[:predicate, [:odd?, [[:input, 16]]]], [:predicate, [:gt?, [[:num, 18], [:input, 16]]]]]]]]
+      )
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns string representation' do
+      expect(operation.to_s).to eql('part(odd?, gt?(18))')
+    end
+  end
+end


### PR DESCRIPTION
* Valid when at least one rule is valid
* Returns AST with all errors in case no rules are valid
* Add visit_set and visit_part to Result

One of the changes I mentioned in:
https://discourse.dry-rb.org/t/extensions-for-dry-logic-and-dry-validations-to-support-open-api-schemas/525

I have 2 questions about the implementation:
1) Is name `part` good?
2) Is it enough to return Result::SUCCESS or should I put successful or failed rules into successful result?