### PR TITLE
Add nil? and make none? an alias for backward compat

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -14,9 +14,10 @@ module Dry
           input.kind_of?(type)
         end
 
-        def none?(input)
+        def nil?(input)
           input.nil?
         end
+        alias_method :none?, :nil?
 
         def key?(name, input)
           input.key?(name)

--- a/spec/shared/predicates.rb
+++ b/spec/shared/predicates.rb
@@ -1,7 +1,7 @@
 require 'dry/logic/predicates'
 
 RSpec.shared_examples 'predicates' do
-  let(:none?) { Dry::Logic::Predicates[:none?] }
+  let(:nil?) { Dry::Logic::Predicates[:nil?] }
 
   let(:array?) { Dry::Logic::Predicates[:array?] }
 

--- a/spec/unit/operations/or_spec.rb
+++ b/spec/unit/operations/or_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Operations::Or do
 
   include_context 'predicates'
 
-  let(:left) { Rule::Predicate.new(none?) }
+  let(:left) { Rule::Predicate.new(nil?) }
   let(:right) { Rule::Predicate.new(gt?).curry(18) }
 
   let(:other) do
@@ -22,7 +22,7 @@ RSpec.describe Operations::Or do
     it 'returns ast' do
       expect(operation.to_ast).to eql(
         [:or, [
-          [:predicate, [:none?, [[:input, Undefined]]]],
+          [:predicate, [:nil?, [[:input, Undefined]]]],
           [:predicate, [:gt?, [[:num, 18], [:input, Undefined]]]]]
         ]
       )
@@ -31,7 +31,7 @@ RSpec.describe Operations::Or do
     it 'returns result ast' do
       expect(operation.(17).to_ast).to eql(
         [:or, [
-          [:predicate, [:none?, [[:input, 17]]]],
+          [:predicate, [:nil?, [[:input, 17]]]],
           [:predicate, [:gt?, [[:num, 18], [:input, 17]]]]]
         ]
       )
@@ -40,7 +40,7 @@ RSpec.describe Operations::Or do
     it 'returns failure result ast' do
       expect(operation.with(id: :age).(17).to_ast).to eql(
         [:failure, [:age, [:or, [
-          [:predicate, [:none?, [[:input, 17]]]],
+          [:predicate, [:nil?, [[:input, 17]]]],
           [:predicate, [:gt?, [[:num, 18], [:input, 17]]]]]
         ]]]
       )
@@ -67,7 +67,7 @@ RSpec.describe Operations::Or do
 
   describe '#to_s' do
     it 'returns string representation' do
-      expect(operation.to_s).to eql('none? OR gt?(18)')
+      expect(operation.to_s).to eql('nil? OR gt?(18)')
     end
   end
 end

--- a/spec/unit/predicates/none_spec.rb
+++ b/spec/unit/predicates/none_spec.rb
@@ -1,8 +1,8 @@
 require 'dry/logic/predicates'
 
 RSpec.describe Dry::Logic::Predicates do
-  describe '#none?' do
-    let(:predicate_name) { :none? }
+  describe '#nil?' do
+    let(:predicate_name) { :nil? }
 
     context 'when value is nil' do
       let(:arguments_list) { [[nil]] }


### PR DESCRIPTION
Originally, dry-validation couldn't use `nil?` because it was defined on `Object`, now it's possible as DSL objects use `BasicObject` or they undef methods that are in conflict with the DSL.