### PR TITLE
CI: Use 2.4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
 rvm:
   - 2.6.2
   - 2.5.5
-  - 2.4.5
+  - 2.4.6
   - jruby-9.2.6.0
   - truffleruby
 env:


### PR DESCRIPTION
This PR updates the CI matrix to use latest 2.4.