### PR TITLE
Add respond_to? predicate

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -204,6 +204,10 @@ module Dry
           format?(uuid_v4_format, input)
         end
 
+        def respond_to?(value, method)
+          value.respond_to?(method)
+        end
+
         def predicate(name, &block)
           define_singleton_method(name, &block)
         end

--- a/spec/unit/predicates/respond_to_spec.rb
+++ b/spec/unit/predicates/respond_to_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'dry/logic/predicates'
+
+RSpec.describe Dry::Logic::Predicates do
+  describe '#respond_to?' do
+    let(:predicate_name) { :respond_to? }
+
+    context 'when value responds to method' do
+      let(:arguments_list) do
+        [
+          [Object, :method],
+          [Hash, :new]
+        ]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+
+    context 'when value does not respond to method' do
+      let(:arguments_list) do
+        [
+          [Object, :foo],
+          [Hash, :bar]
+        ]
+      end
+
+      it_behaves_like 'a failing predicate'
+    end
+  end
+end


### PR DESCRIPTION
This is part of a feature for `dry-types` about being able to define a type by a contract of implemented methods in the value.

Calling the predicate method `respond_to?` has the undesired side effect of obfuscating `Object#respond_to?` in `Dry::Logic::Predicates`. An alternative would be to name it `responds_to?`, but it would be less intuitive for users who would find more natural to have the predicate named like the method. Another solution would be to decouple predicate names from `Dry::Logic::Predicates` method names. What do you think?

**Resources**

- [Original discussion](https://discourse.dry-rb.org/t/support-for-type-classes/759)