### PR TITLE
Switch order of arguments in respond_to predicate

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -204,8 +204,8 @@ module Dry
           format?(uuid_v4_format, input)
         end
 
-        def respond_to?(value, method)
-          value.respond_to?(method)
+        def respond_to?(method, input)
+          input.respond_to?(method)
         end
 
         def predicate(name, &block)

--- a/spec/unit/predicates/respond_to_spec.rb
+++ b/spec/unit/predicates/respond_to_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Dry::Logic::Predicates do
     context 'when value responds to method' do
       let(:arguments_list) do
         [
-          [Object, :method],
-          [Hash, :new]
+          [:method, Object],
+          [:new, Hash]
         ]
       end
 
@@ -20,8 +20,8 @@ RSpec.describe Dry::Logic::Predicates do
     context 'when value does not respond to method' do
       let(:arguments_list) do
         [
-          [Object, :foo],
-          [Hash, :bar]
+          [:foo, Object],
+          [:bar, Hash]
         ]
       end
 


### PR DESCRIPTION
This is the order that `dry-types` expect, and it makes more sense
having function currying in mind

@solnic this should be merged to master. It was my mistake yesterday.

References #55 