### PR TITLE
Adding predicates to support min_bytesize? max_bytesize? and bytesize?

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -114,7 +114,7 @@ module Dry
 
         def size?(size, input)
           case size
-          when Integer then size == input.size
+          when Integer then size.equal?(input.size)
           when Range, Array then size.include?(input.size)
           else
             raise ArgumentError, "+#{size}+ is not supported type for size? predicate."
@@ -131,7 +131,7 @@ module Dry
 
         def bytesize?(size, input)
           case size
-          when Integer then size == input.bytesize
+          when Integer then size.equal?(input.bytesize)
           when Range, Array then size.include?(input.bytesize)
           else
             raise ArgumentError, "+#{size}+ is not supported type for bytesize? predicate."

--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -129,6 +129,23 @@ module Dry
           input.size <= num
         end
 
+        def bytesize?(size, input)
+          case size
+          when Integer then size == input.bytesize
+          when Range, Array then size.include?(input.bytesize)
+          else
+            raise ArgumentError, "+#{size}+ is not supported type for bytesize? predicate."
+          end
+        end
+
+        def min_bytesize?(num, input)
+          input.bytesize >= num
+        end
+
+        def max_bytesize?(num, input)
+          input.bytesize <= num
+        end
+
         def inclusion?(list, input)
           ::Kernel.warn 'inclusion is deprecated - use included_in instead.'
           included_in?(list, input)

--- a/spec/unit/predicates/bytesize_spec.rb
+++ b/spec/unit/predicates/bytesize_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Dry::Logic::Predicates do
       let(:arguments_list) do
         [
           [4, 'こa'],
-          [1..8,  'こa']
+          [1..8, 'こa']
         ]
       end
 
@@ -21,7 +21,7 @@ RSpec.describe Dry::Logic::Predicates do
       let(:arguments_list) do
         [
           [3, 'こa'],
-          [1..3,  'こa']
+          [1..3, 'こa']
         ]
       end
 
@@ -32,7 +32,7 @@ RSpec.describe Dry::Logic::Predicates do
       let(:arguments_list) do
         [
           [5, 'こa'],
-          [5..10,  'こa']
+          [5..10, 'こa']
         ]
       end
 

--- a/spec/unit/predicates/bytesize_spec.rb
+++ b/spec/unit/predicates/bytesize_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'dry/logic/predicates'
+
+RSpec.describe Dry::Logic::Predicates do
+  describe '#bytesize?' do
+    let(:predicate_name) { :bytesize? }
+
+    context 'when value size is equal to n' do
+      let(:arguments_list) do
+        [
+          [4, 'こa'],
+          [1..8,  'こa']
+        ]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+
+    context 'when value size is greater than n' do
+      let(:arguments_list) do
+        [
+          [3, 'こa'],
+          [1..3,  'こa']
+        ]
+      end
+
+      it_behaves_like 'a failing predicate'
+    end
+
+    context 'with value size is less than n' do
+      let(:arguments_list) do
+        [
+          [5, 'こa'],
+          [5..10,  'こa']
+        ]
+      end
+
+      it_behaves_like 'a failing predicate'
+    end
+
+    context 'with an unsupported size' do
+      it 'raises an error' do
+        expect { Predicates[:bytesize?].call('oops', 1) }.to raise_error(ArgumentError, /oops/)
+      end
+    end
+  end
+end

--- a/spec/unit/predicates/max_bytesize_spec.rb
+++ b/spec/unit/predicates/max_bytesize_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'dry/logic/predicates'
+
+RSpec.describe Dry::Logic::Predicates do
+  describe '#max_bytesize?' do
+    let(:predicate_name) { :max_bytesize? }
+
+    context 'when value size is less than n' do
+      let(:arguments_list) do
+        [
+          [5, 'こa']
+        ]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+
+    context 'when value size is equal to n' do
+      let(:arguments_list) do
+        [
+          [5, 'こab']
+        ]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+
+    context 'with value size is greater than n' do
+      let(:arguments_list) do
+        [
+          [5, 'こabc']
+        ]
+      end
+
+      it_behaves_like 'a failing predicate'
+    end
+  end
+end

--- a/spec/unit/predicates/min_bytesize_spec.rb
+++ b/spec/unit/predicates/min_bytesize_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'dry/logic/predicates'
+
+RSpec.describe Dry::Logic::Predicates do
+  describe '#min_bytesize?' do
+    let(:predicate_name) { :min_bytesize? }
+
+    context 'when value size is greater than n' do
+      let(:arguments_list) do
+        [
+          [3, 'こa']
+        ]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+
+    context 'when value size is equal to n' do
+      let(:arguments_list) do
+        [
+          [5, 'こab']
+        ]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+
+    context 'with value size is less than n' do
+      let(:arguments_list) do
+        [
+          [5, 'こ']
+        ]
+      end
+
+      it_behaves_like 'a failing predicate'
+    end
+  end
+end


### PR DESCRIPTION
This is a fairly simple enhancement to validate the byteszie of my string input, not just the character count. 

```
irb(main):017:0> 'こ'.size
=> 1
irb(main):018:0> 'こ'.bytesize
=> 3
```

It follows the same form as min_size?, max_size?, and size? predicates. 

For documentation purposes should I open a pr with? https://github.com/dry-rb/dry-rb.org
Follow up: Add integration test to dry-schema