### PR TITLE
Add metadata to gemspec

### DIFF
--- a/dry-logic.gemspec
+++ b/dry-logic.gemspec
@@ -15,6 +15,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.4.0'
+  
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/dry-rb/dry-logic',
+    'changelog_uri' => 'https://github.com/dry-rb/dry-logic/blob/master/CHANGELOG.md'
+  }
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
   spec.add_runtime_dependency 'dry-core', '~> 0.2'


### PR DESCRIPTION
This PR adds 2 URIs to the gemspec:

* `source_code_uri`
* `changelog_uri`