### PR TITLE
Remove fit from specs

### DIFF
--- a/spec/unit/rule_spec.rb
+++ b/spec/unit/rule_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe Dry::Logic::Rule do
     describe 'constants' do
       let(:options) { { args: [], arity: 0 } }
 
-      fit 'accepts variable number of arguments' do
+      it 'accepts variable number of arguments' do
         expect(rule.method(:call).arity).to be(-1)
         expect(rule.method(:[]).arity).to be(-1)
       end


### PR DESCRIPTION
Here is a small fix which replaces a `fit` with `it`
