### PR TITLE
Explicitly support for nil input in format?

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -199,7 +199,7 @@ module Dry
         end
 
         def format?(regex, input)
-          regex.match?(input)
+          !input.nil? && regex.match?(input)
         end
 
         def case?(pattern, input)

--- a/spec/unit/predicates/format_spec.rb
+++ b/spec/unit/predicates/format_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Dry::Logic::Predicates, '#format?' do
 
   context 'when value matches provided regexp' do
     let(:arguments_list) do
-      [['Foo', /^F/]]
+      [[/^F/, 'Foo']]
     end
 
     it_behaves_like 'a passing predicate'
@@ -15,7 +15,15 @@ RSpec.describe Dry::Logic::Predicates, '#format?' do
 
   context 'when value does not match provided regexp' do
     let(:arguments_list) do
-      [['Bar', /^F/]]
+      [[/^F/, 'Bar']]
+    end
+
+    it_behaves_like 'a failing predicate'
+  end
+
+  context 'when input is nil' do
+    let(:arguments_list) do
+      [[/^F/, nil]]
     end
 
     it_behaves_like 'a failing predicate'


### PR DESCRIPTION
Ruby 2.7-preview2 raises an error when Regexp#match? receives `nil`, this breaks a few tests in dry-schema. This change in ruby was already reverted but may be re-introduced in the future.
See discussions: https://bugs.ruby-lang.org/issues/13083

This also fixes tests, they were wrong from the beginning.

Finally, it's not recommended to rely on this behavior. The `nil` check may be removed in future major versions, it's only added to make tests in dry-schema pass.