### PR TITLE
correct insecure uuid_v4? predicate regexp

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -207,7 +207,7 @@ module Dry
         end
 
         def uuid_v4?(input)
-          uuid_v4_format = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
+          uuid_v4_format = /\A[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\z/i
           format?(uuid_v4_format, input)
         end
 

--- a/spec/unit/predicates/uuid_v4_spec.rb
+++ b/spec/unit/predicates/uuid_v4_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Dry::Logic::Predicates do
     context 'with value is not a valid V4 UUID' do
       let(:arguments_list) do
         [
+          ["not-a-uuid-at-all\nf2d26c57-e07c-4416-a749-57e937930e04"], # V4 with invalid prefix
+          ["f2d26c57-e07c-4416-a749-57e937930e04\nnot-a-uuid-at-all"], # V4 with invalid suffix
           ['f2d26c57-e07c-3416-a749-57e937930e04'], # wrong version number (3, not 4)
           ['20633928-6a07-11e9-a923-1681be663d3e'], # UUID V1
           ['not-a-uuid-at-all']


### PR DESCRIPTION
\A and \z should be used to mark start and end of string.
In other case it will accept strings that for sure are not valid uuids (but include them in one of lines)