### PR TITLE
Change argument name in the "size?" method to "num"

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -112,12 +112,12 @@ module Dry
           !lt?(num, input)
         end
 
-        def size?(size, input)
-          case size
-          when Integer then size.equal?(input.size)
-          when Range, Array then size.include?(input.size)
+        def size?(num, input)
+          case num
+          when Integer then num.equal?(input.size)
+          when Range, Array then num.include?(input.size)
           else
-            raise ArgumentError, "+#{size}+ is not supported type for size? predicate."
+            raise ArgumentError, "+#{num}+ is not supported type for size? predicate."
           end
         end
 


### PR DESCRIPTION
Fixes dry-rb/dry-schema#290

This resolves the issue with inconsistency in the names of interpolated arguments when using translations for dry-schema/dry-validation messages. Now every interpolated argument is called "num" in all "size" connected validations:
"size?", "min_size?", "max_size?".

This was happening because dry-schema calls `predicate.parameters` and uses them to get names of interpolated args in error messages

Btw wasn't sure if this should be "num" or "size". I chose "num" because it will be backward compatible but on the other hand it's less obvious... 