### PR TITLE
Add predicates for checking V1, V2, V3, V5 UUIDs.

### DIFF
--- a/docsite/source/predicates.html.md
+++ b/docsite/source/predicates.html.md
@@ -72,7 +72,11 @@ Predicates[:key?].(:name, {name: 'John'})
   - `format?`
   - `respond_to?`
   - `predicate`
+  - `uuid_v1?`
+  - `uuid_v2?`
+  - `uuid_v3?`
   - `uuid_v4?`
+  - `uuid_v5?`
   - `uri?`
 
 With predicates you can build more composable and complex operations:

--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -206,9 +206,29 @@ module Dry
           pattern === input
         end
 
+        def uuid_v1?(input)
+          uuid_v1_format = /\A[0-9A-F]{8}-[0-9A-F]{4}-1[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\z/i
+          format?(uuid_v1_format, input)
+        end
+
+        def uuid_v2?(input)
+          uuid_v2_format = /\A[0-9A-F]{8}-[0-9A-F]{4}-2[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\z/i
+          format?(uuid_v2_format, input)
+        end
+
+        def uuid_v3?(input)
+          uuid_v3_format = /\A[0-9A-F]{8}-[0-9A-F]{4}-3[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\z/i
+          format?(uuid_v3_format, input)
+        end
+
         def uuid_v4?(input)
           uuid_v4_format = /\A[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\z/i
           format?(uuid_v4_format, input)
+        end
+
+        def uuid_v5?(input)
+          uuid_v5_format = /\A[0-9A-F]{8}-[0-9A-F]{4}-5[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\z/i
+          format?(uuid_v5_format, input)
         end
 
         def uri?(schemes, input)

--- a/spec/unit/predicates/uuid_v1_spec.rb
+++ b/spec/unit/predicates/uuid_v1_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'dry/logic/predicates'
+
+RSpec.describe Dry::Logic::Predicates do
+  describe '#uuid_v1?' do
+    let(:predicate_name) { :uuid_v1? }
+
+    context 'when value is a valid V1 UUID' do
+      let(:arguments_list) do
+        [['f2d26c57-e07c-1416-a749-57e937930e04']]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+
+    context 'with value is not a valid V1 UUID' do
+      let(:arguments_list) do
+        [
+          ["not-a-uuid-at-all\nf2d26c57-e07c-1416-a749-57e937930e04"], # V4 with invalid prefix
+          ["f2d26c57-e07c-1416-a749-57e937930e04\nnot-a-uuid-at-all"], # V4 with invalid suffix
+          ['f2d26c57-e07c-3416-a749-57e937930e04'], # wrong version number (3, not 1)
+          ['20633928-6a07-41e9-a923-1681be663d3e'], # UUID V4
+          ['not-a-uuid-at-all']
+        ]
+      end
+
+      it_behaves_like 'a failing predicate'
+    end
+  end
+end

--- a/spec/unit/predicates/uuid_v2_spec.rb
+++ b/spec/unit/predicates/uuid_v2_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'dry/logic/predicates'
+
+RSpec.describe Dry::Logic::Predicates do
+  describe '#uuid_v2?' do
+    let(:predicate_name) { :uuid_v2? }
+
+    context 'when value is a valid V1 UUID' do
+      let(:arguments_list) do
+        [['f2d26c57-e07c-2416-a749-57e937930e04']]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+
+    context 'with value is not a valid V4 UUID' do
+      let(:arguments_list) do
+        [
+          ["not-a-uuid-at-all\nf2d26c57-e07c-2416-a749-57e937930e04"], # V2 with invalid prefix
+          ["f2d26c57-e07c-2416-a749-57e937930e04\nnot-a-uuid-at-all"], # V2 with invalid suffix
+          ['f2d26c57-e07c-3416-a749-57e937930e04'], # wrong version number (3, not 2)
+          ['20633928-6a07-11e9-a923-1681be663d3e'], # UUID V1
+          ['not-a-uuid-at-all']
+        ]
+      end
+
+      it_behaves_like 'a failing predicate'
+    end
+  end
+end

--- a/spec/unit/predicates/uuid_v3_spec.rb
+++ b/spec/unit/predicates/uuid_v3_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'dry/logic/predicates'
+
+RSpec.describe Dry::Logic::Predicates do
+  describe '#uuid_v3?' do
+    let(:predicate_name) { :uuid_v3? }
+
+    context 'when value is a valid V3 UUID' do
+      let(:arguments_list) do
+        [['f2d26c57-e07c-3416-a749-57e937930e04']]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+
+    context 'with value is not a valid V4 UUID' do
+      let(:arguments_list) do
+        [
+          ["not-a-uuid-at-all\nf2d26c57-e07c-3416-a749-57e937930e04"], # V3 with invalid prefix
+          ["f2d26c57-e07c-3416-a749-57e937930e04\nnot-a-uuid-at-all"], # V3 with invalid suffix
+          ['f2d26c57-e07c-4416-a749-57e937930e04'], # wrong version number (4, not 3)
+          ['20633928-6a07-11e9-a923-1681be663d3e'], # UUID V1
+          ['not-a-uuid-at-all']
+        ]
+      end
+
+      it_behaves_like 'a failing predicate'
+    end
+  end
+end

--- a/spec/unit/predicates/uuid_v5_spec.rb
+++ b/spec/unit/predicates/uuid_v5_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'dry/logic/predicates'
+
+RSpec.describe Dry::Logic::Predicates do
+  describe '#uuid_v5?' do
+    let(:predicate_name) { :uuid_v5? }
+
+    context 'when value is a valid V5 UUID' do
+      let(:arguments_list) do
+        [['f2d26c57-e07c-5416-a749-57e937930e04']]
+      end
+
+      it_behaves_like 'a passing predicate'
+    end
+
+    context 'with value is not a valid V4 UUID' do
+      let(:arguments_list) do
+        [
+          ["not-a-uuid-at-all\nf2d26c57-e07c-5416-a749-57e937930e04"], # V4 with invalid prefix
+          ["f2d26c57-e07c-5416-a749-57e937930e04\nnot-a-uuid-at-all"], # V4 with invalid suffix
+          ['f2d26c57-e07c-3416-a749-57e937930e04'], # wrong version number (3, not 5)
+          ['20633928-6a07-11e9-a923-1681be663d3e'], # UUID V1
+          ['not-a-uuid-at-all']
+        ]
+      end
+
+      it_behaves_like 'a failing predicate'
+    end
+  end
+end


### PR DESCRIPTION
I have a need to validate other versions of UUIDs than just V4. Because the `uuid_v4?` predicate exists, can we also add predicates for other UUID versions?

Should I also add a `uuid?` predicate that checks for V1-V5 UUIDs?

Reference: https://stackoverflow.com/a/38191104