### PR TITLE
Fix incorrect comments in uuid_v1_spec and uuid_v5_spec files.

### DIFF
--- a/spec/unit/predicates/uuid_v1_spec.rb
+++ b/spec/unit/predicates/uuid_v1_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Dry::Logic::Predicates do
     context "with value is not a valid V1 UUID" do
       let(:arguments_list) do
         [
-          ["not-a-uuid-at-all\nf2d26c57-e07c-1416-a749-57e937930e04"], # V4 with invalid prefix
-          ["f2d26c57-e07c-1416-a749-57e937930e04\nnot-a-uuid-at-all"], # V4 with invalid suffix
+          ["not-a-uuid-at-all\nf2d26c57-e07c-1416-a749-57e937930e04"], # V1 with invalid prefix
+          ["f2d26c57-e07c-1416-a749-57e937930e04\nnot-a-uuid-at-all"], # V1 with invalid suffix
           ["f2d26c57-e07c-3416-a749-57e937930e04"], # wrong version number (3, not 1)
           ["20633928-6a07-41e9-a923-1681be663d3e"], # UUID V4
           ["not-a-uuid-at-all"]

--- a/spec/unit/predicates/uuid_v5_spec.rb
+++ b/spec/unit/predicates/uuid_v5_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Dry::Logic::Predicates do
     context "with value is not a valid V4 UUID" do
       let(:arguments_list) do
         [
-          ["not-a-uuid-at-all\nf2d26c57-e07c-5416-a749-57e937930e04"], # V4 with invalid prefix
-          ["f2d26c57-e07c-5416-a749-57e937930e04\nnot-a-uuid-at-all"], # V4 with invalid suffix
+          ["not-a-uuid-at-all\nf2d26c57-e07c-5416-a749-57e937930e04"], # V5 with invalid prefix
+          ["f2d26c57-e07c-5416-a749-57e937930e04\nnot-a-uuid-at-all"], # V5 with invalid suffix
           ["f2d26c57-e07c-3416-a749-57e937930e04"], # wrong version number (3, not 5)
           ["20633928-6a07-11e9-a923-1681be663d3e"], # UUID V1
           ["not-a-uuid-at-all"]


### PR DESCRIPTION
I noticed this morning that some of the comments that I created in https://github.com/dry-rb/dry-logic/pull/75 were incorrect. I have updated these comments. 