### PR TITLE
Better support for negative arity

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -1,4 +1,8 @@
 ---
+- version: 1.0.8
+  date: 'unreleased'
+  fixed:
+  - 'Better Ruby 3 support with fixed specialization for rules of negative arity (@flash-gordon)'
 - version: 1.0.7
   summary:
   date: '2020-08-13'

--- a/spec/unit/rule_spec.rb
+++ b/spec/unit/rule_spec.rb
@@ -219,6 +219,33 @@ RSpec.describe Dry::Logic::Rule do
       end
     end
 
+    describe "-2 arity" do
+      let(:options) { {args: [], arity: -2} }
+
+      it "accepts variable number of arguments" do
+        expect(rule.method(:call).arity).to be(-2)
+        expect(rule.method(:[]).arity).to be(-2)
+      end
+
+      context "curried 1" do
+        let(:options) { {args: [1], arity: -2} }
+
+        it "doesn't have required arguments" do
+          expect(rule.method(:call).arity).to be(-1)
+          expect(rule.method(:[]).arity).to be(-1)
+        end
+      end
+
+      context "curried 2" do
+        let(:options) { {args: [1, 2], arity: -2} }
+
+        it "doesn't have required arguments" do
+          expect(rule.method(:call).arity).to be(-1)
+          expect(rule.method(:[]).arity).to be(-1)
+        end
+      end
+    end
+
     describe "constants" do
       let(:options) { {args: [], arity: 0} }
 


### PR DESCRIPTION
Ruby 3 changed arity of procs made from symbols (because they are lambdas now). This revealed some logic issues (see what I did here). Thanks to this change I finally read the documentation on #arity and required improvements.

P.S. It seems that nobody uses arity < -1 for predicates