### PR TITLE
Extend attr? predicate to optionally match attr value

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -3,11 +3,14 @@
 require "bigdecimal"
 require "bigdecimal/util"
 require "date"
+require "dry/core/constants"
 
 module Dry
   module Logic
     module Predicates
       module Methods
+        include Core::Constants
+
         def [](name)
           method(name)
         end
@@ -25,8 +28,12 @@ module Dry
           input.key?(name)
         end
 
-        def attr?(name, input)
-          input.respond_to?(name)
+        def attr?(name, value = Undefined, input)
+          if Undefined.equal?(value)
+            input.respond_to?(name)
+          else
+            input.respond_to?(name) && input.public_send(name) == value
+          end
         end
 
         def empty?(input)

--- a/spec/unit/predicates/attr_spec.rb
+++ b/spec/unit/predicates/attr_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Dry::Logic::Predicates do
   describe "#attr?" do
     let(:predicate_name) { :attr? }
 
-    context "when value responds to the attr name" do
+    context "when input responds to the attr name" do
       let(:arguments_list) do
         [
           [:name, Struct.new(:name).new("John")],
@@ -15,9 +15,31 @@ RSpec.describe Dry::Logic::Predicates do
       end
 
       it_behaves_like "a passing predicate"
+
+      context "and value matches the attr value" do
+        let(:arguments_list) do
+          [
+            [:name, "John", Struct.new(:name).new("John")],
+            [:age, 18, Struct.new(:age).new(18)]
+          ]
+        end
+
+        it_behaves_like "a passing predicate"
+      end
+
+      context "and value does not matche the attr value" do
+        let(:arguments_list) do
+          [
+            [:name, "Jill", Struct.new(:name).new("John")],
+            [:age, 21, Struct.new(:age).new(18)]
+          ]
+        end
+
+        it_behaves_like "a failing predicate"
+      end
     end
 
-    context "with value does not respond to the attr name" do
+    context "when input does not respond to the attr name" do
       let(:arguments_list) do
         [
           [:name, Struct.new(:age).new(18)],
@@ -26,6 +48,17 @@ RSpec.describe Dry::Logic::Predicates do
       end
 
       it_behaves_like "a failing predicate"
+
+      context "and value does not matche the attr value" do
+        let(:arguments_list) do
+          [
+            [:name, "Jill", Struct.new(:age).new(18)],
+            [:age, 18, Struct.new(:name).new("Jill")]
+          ]
+        end
+
+        it_behaves_like "a failing predicate"
+      end
     end
   end
 end


### PR DESCRIPTION
Extending the `attr?` by keeping the backward compatibility

```ruby
locked_obj = Struct.new(:state).new("locked")
unlocked_obj = Struct.new(:state).new("unlocked")

Dry::Logic::Predicates['attr?'].call(:state, locked_obj)
# => true
Dry::Logic::Predicates['attr?'].call(:state, unlocked_obj)
# => true
Dry::Logic::Predicates['attr?'].call(:state, "locked", locked_obj)
# => true
Dry::Logic::Predicates['attr?'].call(:state, "locked", unlocked_obj)
# => false
```