### PR TITLE
Allow for nested check operations in Ruby 3.0

### DIFF
--- a/lib/dry/logic/operations/check.rb
+++ b/lib/dry/logic/operations/check.rb
@@ -12,7 +12,7 @@ module Dry
 
         def self.new(rule, **options)
           if options[:evaluator]
-            super(rule, options)
+            super(rule, **options)
           else
             keys = options.fetch(:keys)
             evaluator = Evaluator::Set.new(keys)

--- a/spec/unit/operations/check_spec.rb
+++ b/spec/unit/operations/check_spec.rb
@@ -37,6 +37,25 @@ RSpec.describe Dry::Logic::Operations::Check do
         )
       end
     end
+
+    context "with its output as input" do
+      let(:gt?) { Dry::Logic::Predicates[:gt?] }
+      let(:min) { Dry::Logic::Rule::Predicate.new(gt?).curry(18) }
+      let(:inner) { described_class.new(min, keys: [:age]) }
+      let(:outer) { described_class.new(inner, keys: [:person]) }
+
+      subject { outer.call(input) }
+
+      describe "success" do
+        let(:input) { {person: {age: 20}} }
+        it { is_expected.to be_a_success }
+      end
+
+      describe "failure" do
+        let(:input) { {person: {age: 10}} }
+        it { is_expected.not_to be_a_success }
+      end
+    end
   end
 
   describe "#to_ast" do


### PR DESCRIPTION
When nesting two `Operations::Check` calls

- Ruby 2.7 displays the following warning: `Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`.
- Ruby 3.0 raises the following error: `undefined method '[]' for nil:NilClass`.

This PR should resolve both problems.