### PR TITLE
Implement parsing string representations back to AST.

### DIFF
--- a/lib/dry/logic/operations/check.rb
+++ b/lib/dry/logic/operations/check.rb
@@ -48,6 +48,10 @@ module Dry
         def ast(input = Undefined)
           [type, [options[:keys], rule.ast(input)]]
         end
+
+        def to_s
+          "#{type}[#{options[:keys].join(",")}](#{rule})"
+        end
       end
     end
   end

--- a/lib/dry/logic/rule_interpreter.rb
+++ b/lib/dry/logic/rule_interpreter.rb
@@ -12,13 +12,13 @@ module Dry
     class RuleInterpreter
       include Core::Constants
 
-      BINARY_OPS = { "AND" => :and, "XOR" => :xor, "OR" => :or, "THEN" => :implication }.freeze
+      BINARY_OPS = {"AND" => :and, "XOR" => :xor, "OR" => :or, "THEN" => :implication}.freeze
 
       PATTERNS = {
         binary_op: Regexp.new("\\s+(?:#{Regexp.union(BINARY_OPS.keys).source})\s+"),
-         check_op: /\Acheck\[(.+)\]\((.+)\)/,
-           key_op: /\A(attr|key)\[(.+)\]\((.+)\)/,
-         unary_op: /\A(\w+(?!\?))\((.+)\)/,
+        check_op: /\Acheck\[(.+)\]\((.+)\)/,
+        key_op: /\A(attr|key)\[(.+)\]\((.+)\)/,
+        unary_op: /\A(\w+(?!\?))\((.+)\)/,
         predicate: /\A(\w+\?)(\((.+)\))?/
       }.freeze
 
@@ -102,3 +102,4 @@ module Dry
     end
   end
 end
+

--- a/lib/dry/logic/rule_interpreter.rb
+++ b/lib/dry/logic/rule_interpreter.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "dry/core/constants"
+
+require "dry/logic/rule"
+require "dry/logic/rule/predicate"
+
+require "dry/logic/rule_compiler"
+
+module Dry
+  module Logic
+    class RuleInterpreter
+      include Core::Constants
+
+      BINARY_OPS = {
+        'AND'  => :and,
+        'XOR'  => :xor,
+        'OR'   => :or,
+        'THEN' => :implication
+      }
+
+      PATTERNS = {
+        :binary_op => Regexp.new("\\s+(?:#{Regexp.union(BINARY_OPS.keys).source})\\s+"),
+        :check_op  => /\Acheck\[(.+)\]\((.+)\)/,
+        :key_op    => /\A(attr|key)\[(.+)\]\((.+)\)/,
+        :unary_op  => /\A(\w+(?!\?))\((.+)\)/,
+        :predicate => /\A(\w+\?)(\((.+)\))?/
+      }
+
+      attr_reader :predicates
+
+      def initialize(predicates)
+        @predicates = predicates
+      end
+
+      def compiler
+        @compiler ||= RuleCompiler.new(@predicates)
+      end
+
+      def compile(string)
+        ast = call(string)
+        ast = [ast] unless ast[0].is_a?(Array)
+        compiler.(ast)
+      end
+
+      def call(*rules)
+        rules.map do |rule|
+          case rule
+          when String
+            read_with_patterns(rule) || eval_string(rule)
+          else
+            rule
+          end
+        end
+      end
+
+      def read_with_patterns(rule)
+        PATTERNS.inject(nil) do |a, (key, pattern)|
+          a || pattern.match(rule) { |m| visit(key, m) }
+        end
+      end
+
+      def visit(key, m)
+        send(:"visit_#{key}", m)
+      end
+
+      def visit_binary_op(m)
+        op = m[0].strip
+        [BINARY_OPS.fetch(op), call(m.pre_match, m.post_match)]
+      end
+
+      def visit_unary_op(m)
+        visit(m[1].to_sym, m[2])
+      end
+
+      def visit_each(string)
+        [:each, *call(string)]
+      end
+
+      def visit_set(string)
+        [:set, call(string)]
+      end
+
+      def visit_not(string)
+        [:not, *call(string)]
+      end
+
+      def visit_key_op(m)
+        [m[1].to_sym, call(*m.values_at(2, 3))]
+      end
+
+      def visit_check_op(m)
+        [:check, [m[1].split(",").map(&:to_sym), *call(m[2])]]
+      end
+
+      def visit_predicate_params(name, args)
+        params = Predicates[name].parameters.map(&:last)
+        params.map.with_index { |name, idx| [name, args.fetch(idx, Undefined)] }
+      end
+
+      def visit_predicate(m)
+        name = m[1].to_sym
+        args = m[2] ? m[3].split(',').flat_map { |v| call(v) } : EMPTY_ARRAY
+        [:predicate, [name, visit_predicate_params(name, args)]]
+      end
+
+      def eval_string(rule)
+        eval(rule)
+      rescue NameError
+        rule.to_sym
+      end
+    end
+  end
+end

--- a/spec/unit/rule_compiler_spec.rb
+++ b/spec/unit/rule_compiler_spec.rb
@@ -50,14 +50,6 @@ RSpec.describe Dry::Logic::RuleCompiler, "#call" do
     expect(rules).to eql([check_op])
   end
 
-  it "compiles attr rules" do
-    ast = [[:attr, [:email, [:predicate, [:filled?, [[:input, undefined]]]]]]]
-
-    rules = compiler.(ast)
-
-    expect(rules).to eql([attr_op])
-  end
-
   it "compiles negated rules" do
     ast = [[:not, [:key, [:email, [:predicate, [:filled?, [[:input, undefined]]]]]]]]
 

--- a/spec/unit/rule_interpreter_spec.rb
+++ b/spec/unit/rule_interpreter_spec.rb
@@ -72,3 +72,4 @@ RSpec.describe Dry::Logic::RuleInterpreter, "#call" do
     expect(rules).to eql([each_op])
   end
 end
+

--- a/spec/unit/rule_interpreter_spec.rb
+++ b/spec/unit/rule_interpreter_spec.rb
@@ -28,31 +28,37 @@ RSpec.describe Dry::Logic::RuleInterpreter, "#call" do
 
   it "interpretes key rules" do
     rules = interpreter.compile("key[email](filled?)")
+
     expect(rules).to eql([key_op])
   end
 
   it "interpretes attr rules" do
     rules = interpreter.compile("attr[email](filled?)")
+
     expect(rules).to eql([attr_op])
   end
 
   it "interpretes check rules" do
     rules = interpreter.compile("check[email](filled?)")
+
     expect(rules).to eql([check_op])
   end
 
   it "interpretes negated rules" do
     rules = interpreter.compile("not(key[email](filled?))")
+
     expect(rules).to eql([not_key_op])
   end
 
   it "interpretes and rules" do
     rules = interpreter.compile("key[email](key?(:email)) AND filled?")
+
     expect(rules).to eql([and_op])
   end
 
   it "interpretes or rules" do
     rules = interpreter.compile("key[email](key?(:email)) OR filled?")
+
     expect(rules).to eql([or_op])
   end
 
@@ -69,6 +75,7 @@ RSpec.describe Dry::Logic::RuleInterpreter, "#call" do
 
   it "interpretes each rules" do
     rules = interpreter.compile("each(filled?)")
+
     expect(rules).to eql([each_op])
   end
 end

--- a/spec/unit/rule_interpreter_spec.rb
+++ b/spec/unit/rule_interpreter_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "dry/logic/rule_interpreter"
+
+RSpec.describe Dry::Logic::RuleInterpreter, "#call" do
+  subject(:interpreter) { described_class.new(predicates) }
+
+  let(:predicates) {
+    {key?: predicate,
+     attr?: predicate,
+     filled?: predicate,
+     gt?: predicate,
+     one: predicate}
+  }
+
+  let(:predicate) { double(:predicate, name: :test?, arity: 2).as_null_object }
+
+  let(:rule) { Dry::Logic::Rule::Predicate.build(predicate) }
+  let(:key_op) { Dry::Logic::Operations::Key.new(rule, name: :email) }
+  let(:attr_op) { Dry::Logic::Operations::Attr.new(rule, name: :email) }
+  let(:check_op) { Dry::Logic::Operations::Check.new(rule, keys: [:email]) }
+  let(:not_key_op) { Dry::Logic::Operations::Negation.new(key_op) }
+  let(:and_op) { key_op.curry(:email) & rule }
+  let(:or_op) { key_op.curry(:email) | rule }
+  let(:xor_op) { key_op.curry(:email) ^ rule }
+  let(:set_op) { Dry::Logic::Operations::Set.new(rule) }
+  let(:each_op) { Dry::Logic::Operations::Each.new(rule) }
+
+  it "interpretes key rules" do
+    rules = interpreter.compile("key[email](filled?)")
+    expect(rules).to eql([key_op])
+  end
+
+  it "interpretes attr rules" do
+    rules = interpreter.compile("attr[email](filled?)")
+    expect(rules).to eql([attr_op])
+  end
+
+  it "interpretes check rules" do
+    rules = interpreter.compile("check[email](filled?)")
+    expect(rules).to eql([check_op])
+  end
+
+  it "interpretes negated rules" do
+    rules = interpreter.compile("not(key[email](filled?))")
+    expect(rules).to eql([not_key_op])
+  end
+
+  it "interpretes and rules" do
+    rules = interpreter.compile("key[email](key?(:email)) AND filled?")
+    expect(rules).to eql([and_op])
+  end
+
+  it "interpretes or rules" do
+    rules = interpreter.compile("key[email](key?(:email)) OR filled?")
+    expect(rules).to eql([or_op])
+  end
+
+  it "interpretes exclusive or rules" do
+    rules = interpreter.compile("key[email](key?(:email)) XOR filled?")
+    expect(rules).to eql([xor_op])
+  end
+
+  it "interpretes set rules" do
+    rules = interpreter.compile("set(filled?)")
+
+    expect(rules).to eql([set_op])
+  end
+
+  it "interpretes each rules" do
+    rules = interpreter.compile("each(filled?)")
+    expect(rules).to eql([each_op])
+  end
+end


### PR DESCRIPTION
`RuleInterpreter` takes string representations of rules, predicates or operations and parses them back to AST, which can be compiled to a rule object. So, it makes an ability to store rules as a plain text, for example in db columns, and run them as usual.

```ruby
interpreter = Dry::Logic::RuleInterpreter.new(Dry::Logic::Predicates)
rule = "key?(:email)"

interpreter.(rule) 
# => [[:predicate, [:key?, [[:name, :email], [:input, Undefined]]]]]

interpreter.compile(rule)
# => #<Dry::Logic::Rule::Predicate::Predicate2Arity1Curried predicate=#<Method: Dry::Logic::Predicates.key?> options={:args=>[:user], :arity=>2}>

interpreter.compile(rule)[0].to_s == rule
# => true
```

To implement that feature, I have had to override `Dry::Logic::Operations::Check#to_s` method to hold required args.

The name of the class may be controversial, I will rename it if you've got a better one.