### PR TITLE
Change arity of binary op constructor

### DIFF
--- a/lib/dry/logic/operations/binary.rb
+++ b/lib/dry/logic/operations/binary.rb
@@ -10,9 +10,10 @@ module Dry
 
         attr_reader :right
 
-        def initialize(*rules, **options)
+        def initialize(left, right, **options)
           super
-          @left, @right = rules
+          @left = left
+          @right = right
         end
 
         def ast(input = Undefined)


### PR DESCRIPTION
This doesn't really change much but fixes a subtle issue with jruby found in https://github.com/dry-rb/dry-schema/pull/348 It's hard to say whether it's a bug in jruby because it's an intersection of `undef :respond_to?`, `BasicObject` and implicit coercion to keywords. Keywords situation will improve over time so I think jruby shouldn't bother fixing this particular case.