### PR TITLE
Fix issue if we send not string to format?

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -199,7 +199,7 @@ module Dry
         end
 
         def format?(regex, input)
-          !input.nil? && regex.match?(input)
+          !input.nil? && str?(input) && regex.match?(input)
         end
 
         def case?(pattern, input)

--- a/spec/unit/predicates/format_spec.rb
+++ b/spec/unit/predicates/format_spec.rb
@@ -28,4 +28,12 @@ RSpec.describe Dry::Logic::Predicates, "#format?" do
 
     it_behaves_like "a failing predicate"
   end
+
+  context "when input is nil" do
+    let(:arguments_list) do
+      [[/^F/, 1]]
+    end
+
+    it_behaves_like "a failing predicate"
+  end
 end


### PR DESCRIPTION
Hi there, 

I find an issue in dry-validation related to this repo.

If we do:
```ruby
required(:id).filled(:uuid_v4?)
```

instead of 

```ruby
required(:id).value(:string, :uuid_v4?)
```

It raise an error when someone send an integer with this error: `TypeError: no implicit conversion of Integer into String`

So I'm wondering if we can add `str?(input)` in the `format?` method. 

What do you think ? 

Thanks a lot 