### PR TITLE
Fix NameError: uninitialized constant Dry::Logic::Predicates::Methods::URI

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -3,6 +3,7 @@
 require "bigdecimal"
 require "bigdecimal/util"
 require "date"
+require "open-uri"
 
 module Dry
   module Logic

--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -3,7 +3,7 @@
 require "bigdecimal"
 require "bigdecimal/util"
 require "date"
-require "open-uri"
+require "uri"
 
 module Dry
   module Logic


### PR DESCRIPTION
This should fix the test errors with Ruby 3.0

```
  1) predicates uri? [:http, :https] success behaves like predicate 
     Failure/Error: uri_format = URI::DEFAULT_PARSER.make_regexp(schemes)

     NameError:
       uninitialized constant Dry::Logic::Predicates::Methods::URI
```

Please check with earlier Ruby versions.