### PR TITLE
Rename eql? into eq? and not_eql? into not_eq?

### DIFF
--- a/docsite/source/predicates.html.md
+++ b/docsite/source/predicates.html.md
@@ -80,23 +80,23 @@ is_very_specific.call(nil).success? # => false
 is_very_specific.call(:some).success? # => false
 ```
 
-### Equality (`eql?`)
+### Equality (`eq?`)
 
 > Returns true when the input is equal to the provided value. Similar to `Object#eql?`
 
 ``` ruby
-is_zero = build { eql?(0) }
+is_zero = build { eq?(0) }
 
 is_zero.call(0).success? # => true
 is_zero.call(10).success? # => false
 ```
 
-### Inequality (`not_eql?`)
+### Inequality (`not_eq?`)
 
 > Returns true when the input does not equal the provided value. Similar to Ruby's `!=` operator
 
 ``` ruby
-is_present = build { not_eql?(nil) }
+is_present = build { not_eq?(nil) }
 
 is_present.call("hello").success? # => true
 is_present.call(nil).success? # => false

--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -178,7 +178,7 @@ module Dry
           !includes?(value, input)
         end
 
-        def eql?(left, right)
+        def eq?(left, right)
           left.eql?(right)
         end
 
@@ -186,7 +186,7 @@ module Dry
           left.equal?(right)
         end
 
-        def not_eql?(left, right)
+        def not_eq?(left, right)
           !left.eql?(right)
         end
 

--- a/spec/integration/builder/predicate_spec.rb
+++ b/spec/integration/builder/predicate_spec.rb
@@ -888,8 +888,8 @@ RSpec.describe "predicates" do
   end
 
   describe "compare methods" do
-    describe :eql? do
-      let(:expression) { ->(*) { eql?(10) } }
+    describe :eq? do
+      let(:expression) { ->(*) { eq?(10) } }
 
       describe "success" do
         it_behaves_like "predicate" do
@@ -906,8 +906,8 @@ RSpec.describe "predicates" do
       end
     end
 
-    describe :not_eql? do
-      let(:expression) { ->(*) { not_eql?(10) } }
+    describe :not_eq? do
+      let(:expression) { ->(*) { not_eq?(10) } }
 
       describe "success" do
         it_behaves_like "predicate" do

--- a/spec/shared/predicates.rb
+++ b/spec/shared/predicates.rb
@@ -29,7 +29,7 @@ RSpec.shared_examples "predicates" do
 
   let(:attr?) { Dry::Logic::Predicates[:attr?] }
 
-  let(:eql?) { Dry::Logic::Predicates[:eql?] }
+  let(:eq?) { Dry::Logic::Predicates[:eq?] }
 
   let(:size?) { Dry::Logic::Predicates[:size?] }
 

--- a/spec/unit/operations/check_spec.rb
+++ b/spec/unit/operations/check_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Dry::Logic::Operations::Check do
   describe "#call" do
     context "with 1-level nesting" do
       subject(:operation) do
-        described_class.new(Dry::Logic::Rule::Predicate.build(eql?).curry(1), id: :compare, keys: [:num])
+        described_class.new(Dry::Logic::Rule::Predicate.build(eq?).curry(1), id: :compare, keys: [:num])
       end
 
       it "applies predicate to args extracted from the input" do
@@ -18,7 +18,7 @@ RSpec.describe Dry::Logic::Operations::Check do
     context "with 2-levels nesting" do
       subject(:operation) do
         described_class.new(
-          Dry::Logic::Rule::Predicate.build(eql?), id: :compare, keys: [[:nums, :left], [:nums, :right]]
+          Dry::Logic::Rule::Predicate.build(eq?), id: :compare, keys: [[:nums, :left], [:nums, :right]]
         )
       end
 
@@ -32,7 +32,7 @@ RSpec.describe Dry::Logic::Operations::Check do
 
         expect(result.to_ast).to eql(
           [:failure, [:compare, [:check, [
-            [[:nums, :left], [:nums, :right]], [:predicate, [:eql?, [[:left, 1], [:right, 2]]]]
+            [[:nums, :left], [:nums, :right]], [:predicate, [:eq?, [[:left, 1], [:right, 2]]]]
           ]]]]
         )
       end

--- a/spec/unit/predicates/eql_spec.rb
+++ b/spec/unit/predicates/eql_spec.rb
@@ -2,8 +2,8 @@
 
 require "dry/logic/predicates"
 
-RSpec.describe Dry::Logic::Predicates, "#eql?" do
-  let(:predicate_name) { :eql? }
+RSpec.describe Dry::Logic::Predicates, "#eq?" do
+  let(:predicate_name) { :eq? }
 
   context "when value is equal to the arg" do
     let(:arguments_list) do

--- a/spec/unit/predicates/not_eql_spec.rb
+++ b/spec/unit/predicates/not_eql_spec.rb
@@ -2,8 +2,8 @@
 
 require "dry/logic/predicates"
 
-RSpec.describe Dry::Logic::Predicates, "#not_eql?" do
-  let(:predicate_name) { :not_eql? }
+RSpec.describe Dry::Logic::Predicates, "#not_eq?" do
+  let(:predicate_name) { :not_eq? }
 
   context "when value is equal to the arg" do
     let(:arguments_list) do


### PR DESCRIPTION
Fix: https://github.com/dry-rb/dry-logic/issues/92

I totally understand that this is a breaking API change but I figured it's worth a try.