### PR TITLE
Add uri_rfc3986? matcher to support validating full URL

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -250,6 +250,10 @@ module Dry
           format?(uri_format, input)
         end
 
+        def uri_rfc3986?(input)
+          format?(URI::RFC3986_Parser::RFC3986_URI, input)
+        end
+
         def respond_to?(method, input)
           input.respond_to?(method)
         end

--- a/spec/unit/predicates/uri_spec.rb
+++ b/spec/unit/predicates/uri_spec.rb
@@ -32,4 +32,31 @@ RSpec.describe Dry::Logic::Predicates do
       it_behaves_like "a failing predicate"
     end
   end
+
+  describe "#uri_rfc3986?" do
+    let(:predicate_name) { :uri_rfc3986? }
+
+    context "when value is a valid URI" do
+      let(:arguments_list) do
+        [
+          ["https://github.com/dry-rb/dry-logic"], # with https format
+          ["mailto:myemail@host.com"], # with mailto format
+          ["urn:isbn:0451450523"] # with URN format
+        ]
+      end
+
+      it_behaves_like "a passing predicate"
+    end
+
+    context "with value is not a valid URI" do
+      let(:arguments_list) do
+        [
+          ["not-a-uri-at-all"],
+          ["[https://github.com/dry-rb/dry-logic]"]
+        ]
+      end
+
+      it_behaves_like "a failing predicate"
+    end
+  end
 end


### PR DESCRIPTION
I use `uri?` predicate to validate whether a string is an valid URI. However, this case fails:

```ruby
schema = Dry::Schema.JSON do
  required(:picture_url).filled(:string, uri?: 'https')
end

schema.call(picture_url: '{https://picture.com/some_image.png}')
# => return successful, while it should be failed.
```

Upon reading code of `URI` module, I notice that `URI::DEFAULT_PARSER.make_regexp` creates a regex that matches only part of the string, and I have no way to avoid that behavior, aside from switching to `URI::RFC3986_Parser::RFC3986_URI`:

```ruby
schema = Dry::Schema.JSON do
  required(:picture_url).filled(:string, format?: URI::RFC3986_Parser::RFC3986_URI)
end
```

However, this prevent me from using the nice error message that comes with `uri?` predicate. I suppose some people would have the same problems as me, so I would like to contribute it back to the repo.

I understand that changing `uri?` itself would be a breaking change, so I want to avoid that, and add a new `uri_rfc3986?` predicate instead. If people start using it over `uri?`, maybe we can consider deprecate `uri?` and replace it with `uri_rfc3986?` in v2.0.