### PR TITLE
Add empty Operations module to fix spurious loading issues

### DIFF
--- a/lib/dry/logic/operations.rb
+++ b/lib/dry/logic/operations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Dry
+  module Logic
+    module Operations
+    end
+  end
+end


### PR DESCRIPTION
Ran into this load error when trying to run tests in a bespoke CI environment:

```
LoadError:
  cannot load such file -- .../lib/dry/logic/operations
  # .../lib/dry/logic/operators.rb:7:in `require'
  # .../lib/dry/logic/operators.rb:7:in `and'
```

I believe that this has to do with Zeitwerk loading and the order that things get loaded. It's trying to load the `operations` file but it's not there. Adding this file with a module declaration fixes this issue, and seems most consistent with Ruby patterns (a file named the same as a directory that declares the directory's module).