### PR TITLE
Check something is a string before checking its format

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -221,7 +221,7 @@ module Dry
         end
 
         def format?(regex, input)
-          !input.nil? && regex.match?(input)
+          !input.nil? && input.is_a?(String) && regex.match?(input)
         end
 
         def case?(pattern, input)

--- a/spec/unit/predicates/uri_spec.rb
+++ b/spec/unit/predicates/uri_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Dry::Logic::Predicates do
         [
           ["http", "mailto:myemail@host.com"], # scheme not allowed
           [%w[http https], "ftp:://myftp.com"], # scheme not allowed
-          ["", "not-a-uri-at-all"]
+          ["", "not-a-uri-at-all"],
+          ["", Hash.new] # Not even a string
         ]
       end
 
@@ -52,7 +53,8 @@ RSpec.describe Dry::Logic::Predicates do
       let(:arguments_list) do
         [
           ["not-a-uri-at-all"],
-          ["[https://github.com/dry-rb/dry-logic]"]
+          ["[https://github.com/dry-rb/dry-logic]"],
+          [Hash.new] # Not even a string
         ]
       end
 

--- a/spec/unit/predicates/uuid_v1_spec.rb
+++ b/spec/unit/predicates/uuid_v1_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe Dry::Logic::Predicates do
           ["f2d26c57-e07c-1416-a749-57e937930e04\nnot-a-uuid-at-all"], # V1 with invalid suffix
           ["f2d26c57-e07c-3416-a749-57e937930e04"], # wrong version number (3, not 1)
           ["20633928-6a07-41e9-a923-1681be663d3e"], # UUID V4
-          ["not-a-uuid-at-all"]
+          ["not-a-uuid-at-all"],
+          [Hash.new] # Not even a string
         ]
       end
 

--- a/spec/unit/predicates/uuid_v2_spec.rb
+++ b/spec/unit/predicates/uuid_v2_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe Dry::Logic::Predicates do
           ["f2d26c57-e07c-2416-a749-57e937930e04\nnot-a-uuid-at-all"], # V2 with invalid suffix
           ["f2d26c57-e07c-3416-a749-57e937930e04"], # wrong version number (3, not 2)
           ["20633928-6a07-11e9-a923-1681be663d3e"], # UUID V1
-          ["not-a-uuid-at-all"]
+          ["not-a-uuid-at-all"],
+          [Hash.new] # Not even a string
         ]
       end
 

--- a/spec/unit/predicates/uuid_v3_spec.rb
+++ b/spec/unit/predicates/uuid_v3_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe Dry::Logic::Predicates do
           ["f2d26c57-e07c-3416-a749-57e937930e04\nnot-a-uuid-at-all"], # V3 with invalid suffix
           ["f2d26c57-e07c-4416-a749-57e937930e04"], # wrong version number (4, not 3)
           ["20633928-6a07-11e9-a923-1681be663d3e"], # UUID V1
-          ["not-a-uuid-at-all"]
+          ["not-a-uuid-at-all"],
+          [Hash.new] # Not even a string
         ]
       end
 

--- a/spec/unit/predicates/uuid_v4_spec.rb
+++ b/spec/unit/predicates/uuid_v4_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe Dry::Logic::Predicates do
           ["f2d26c57-e07c-4416-a749-57e937930e04\nnot-a-uuid-at-all"], # V4 with invalid suffix
           ["f2d26c57-e07c-3416-a749-57e937930e04"], # wrong version number (3, not 4)
           ["20633928-6a07-11e9-a923-1681be663d3e"], # UUID V1
-          ["not-a-uuid-at-all"]
+          ["not-a-uuid-at-all"],
+          [Hash.new] # Not even a string
         ]
       end
 

--- a/spec/unit/predicates/uuid_v5_spec.rb
+++ b/spec/unit/predicates/uuid_v5_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe Dry::Logic::Predicates do
           ["f2d26c57-e07c-5416-a749-57e937930e04\nnot-a-uuid-at-all"], # V5 with invalid suffix
           ["f2d26c57-e07c-3416-a749-57e937930e04"], # wrong version number (3, not 5)
           ["20633928-6a07-11e9-a923-1681be663d3e"], # UUID V1
-          ["not-a-uuid-at-all"]
+          ["not-a-uuid-at-all"],
+          [Hash.new] # Not even a string
         ]
       end
 


### PR DESCRIPTION
Currently, checking if a non-string is a UUID or a URI causes the following error to be thrown:
```
TypeError: no implicit conversion of Hash into String
```

This corrects that and means it instead behaves like a failed predicate.