### PR TITLE
Add predicates for UUIDv6/7/8

### DIFF
--- a/lib/dry/logic/predicates.rb
+++ b/lib/dry/logic/predicates.rb
@@ -29,6 +29,12 @@ module Dry
 
         UUIDv5 = uuid_format(5)
 
+        UUIDv6 = uuid_format(6)
+
+        UUIDv7 = uuid_format(7)
+
+        UUIDv8 = uuid_format(8)
+
         def [](name)
           method(name)
         end
@@ -250,6 +256,18 @@ module Dry
 
         def uuid_v5?(input)
           format?(UUIDv5, input)
+        end
+
+        def uuid_v6?(input)
+          format?(UUIDv6, input)
+        end
+
+        def uuid_v7?(input)
+          format?(UUIDv7, input)
+        end
+
+        def uuid_v8?(input)
+          format?(UUIDv8, input)
         end
 
         def uri?(schemes, input)

--- a/spec/unit/predicates/uuid_v5_spec.rb
+++ b/spec/unit/predicates/uuid_v5_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Dry::Logic::Predicates do
       it_behaves_like "a passing predicate"
     end
 
-    context "with value is not a valid V4 UUID" do
+    context "with value is not a valid V5 UUID" do
       let(:arguments_list) do
         [
           ["not-a-uuid-at-all\nf2d26c57-e07c-5416-a749-57e937930e04"], # V5 with invalid prefix

--- a/spec/unit/predicates/uuid_v6_spec.rb
+++ b/spec/unit/predicates/uuid_v6_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "dry/logic/predicates"
+
+RSpec.describe Dry::Logic::Predicates do
+  describe "#uuid_v6?" do
+    let(:predicate_name) { :uuid_v6? }
+
+    context "when value is a valid V6 UUID" do
+      let(:arguments_list) do
+        [["1ec9414c-232a-6b00-b3c8-9e6bdeced846"]]
+      end
+
+      it_behaves_like "a passing predicate"
+    end
+
+    context "with value is not a valid V6 UUID" do
+      let(:arguments_list) do
+        [
+          ["not-a-uuid-at-all\n1ec9414c-232a-6b00-b3c8-9e6bdeced846"], # V6 with invalid prefix
+          ["1ec9414c-232a-6b00-b3c8-9e6bdeced846\nnot-a-uuid-at-all"], # V6 with invalid suffix
+          ["1ec9414c-232a-3b00-b3c8-9e6bdeced846"], # wrong version number (3, not 6)
+          ["20633928-6a07-11e9-a923-1681be663d3e"], # UUID V1
+          ["not-a-uuid-at-all"]
+        ]
+      end
+
+      it_behaves_like "a failing predicate"
+    end
+  end
+end

--- a/spec/unit/predicates/uuid_v7_spec.rb
+++ b/spec/unit/predicates/uuid_v7_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "dry/logic/predicates"
+
+RSpec.describe Dry::Logic::Predicates do
+  describe "#uuid_v7?" do
+    let(:predicate_name) { :uuid_v7? }
+
+    context "when value is a valid V7 UUID" do
+      let(:arguments_list) do
+        [["017f22e2-79b0-7cc3-98c4-dc0c0c07398f"]]
+      end
+
+      it_behaves_like "a passing predicate"
+    end
+
+    context "with value is not a valid V7 UUID" do
+      let(:arguments_list) do
+        [
+          ["not-a-uuid-at-all\n017f22e2-79b0-7cc3-98c4-dc0c0c07398f"], # V6 with invalid prefix
+          ["017f22e2-79b0-7cc3-98c4-dc0c0c07398f\nnot-a-uuid-at-all"], # V6 with invalid suffix
+          ["017f22e2-79b0-4cc3-98c4-dc0c0c07398f"], # wrong version number (4, not 7)
+          ["20633928-6a07-11e9-a923-1681be663d3e"], # UUID V1
+          ["not-a-uuid-at-all"]
+        ]
+      end
+
+      it_behaves_like "a failing predicate"
+    end
+  end
+end

--- a/spec/unit/predicates/uuid_v8_spec.rb
+++ b/spec/unit/predicates/uuid_v8_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "dry/logic/predicates"
+
+RSpec.describe Dry::Logic::Predicates do
+  describe "#uuid_v8?" do
+    let(:predicate_name) { :uuid_v8? }
+
+    context "when value is a valid V8 UUID" do
+      let(:arguments_list) do
+        [["320c3d4d-cc00-875b-8ec9-32d5f69181c0"]]
+      end
+
+      it_behaves_like "a passing predicate"
+    end
+
+    context "with value is not a valid V8 UUID" do
+      let(:arguments_list) do
+        [
+          ["not-a-uuid-at-all\n320c3d4d-cc00-875b-8ec9-32d5f69181c0"], # V6 with invalid prefix
+          ["320c3d4d-cc00-875b-8ec9-32d5f69181c0\nnot-a-uuid-at-all"], # V6 with invalid suffix
+          ["320c3d4d-cc00-475b-8ec9-32d5f69181c0"], # wrong version number (4, not 8)
+          ["20633928-6a07-11e9-a923-1681be663d3e"], # UUID V1
+          ["not-a-uuid-at-all"]
+        ]
+      end
+
+      it_behaves_like "a failing predicate"
+    end
+  end
+end


### PR DESCRIPTION
While the [updates](https://datatracker.ietf.org/wg/uuidrev/about/) is in a Proposed Standard status, there is already some implementations in the wild and some people (including me) are considering using it in a database for better indexing. Test values taken from the [IETF repository](https://github.com/ietf-wg-uuidrev/rfc4122bis/blob/main/editor-files/draft-peabody-dispatch-new-uuid-format-04.md)