### PR TITLE
Fix broken negation example in documentation

### DIFF
--- a/docsite/source/operations.html.md
+++ b/docsite/source/operations.html.md
@@ -152,7 +152,7 @@ is_natural_and_odd.call(-1).success? # => false
 
 ``` ruby
 is_present = build do
-  negation(empty?)
+  negation { empty? }
 end
 
 is_present.call([1]).success? # => true
@@ -166,7 +166,7 @@ is_present.call("").success? # => false
 ``` ruby
 is_named = build do
   key name: [:user, :name] do
-    str? & negation(empty?)
+    str? & negation { empty? }
   end
 end
 


### PR DESCRIPTION
### What is this change?

The existing examples for negation when used verbatim result in the following error:

```
dry-logic-1.5.0/lib/dry/logic/builder.rb:48:in `instance_eval': wrong number of arguments (given 0, expected 1..3) (ArgumentError)

          instance_eval(&context)
                        ^^^^^^^^
```

From the error and the test cases it looks like this is intended to be invoked with a block.

This PR updates the documentation with a working example.